### PR TITLE
Propagate return value

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -76,7 +76,7 @@ function makeTestBody(param, test, isAsync) {
     };
   }
   return function() {
-    test.apply(this, param);
+    return test.apply(this, param);
   };
 }
 

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -33,6 +33,16 @@ describe('mocha-each', () => {
     assert.equal(test.thisValues[0], _this);
   });
 
+  it('returns the return value of the test function', () => {
+    const expected = 'test';
+    const test = () => { return expected; };
+    const _it = (name, b) => body = b;
+    let body;
+    forEach([0], _it).it('', test);
+    const returnValue = body.call(null);
+    assert.equal(returnValue, expected);
+  });
+
   context('without Mocha', () => {
     it('throws an error when called', () => {
       delete global.it;
@@ -156,6 +166,7 @@ describe('mocha-each', () => {
         body.call(expectedThis, () => {});
         assert.equal(actualThis, expectedThis);
       });
+
     });
 
     context('when the lengths of parameters are different', () => {
@@ -274,4 +285,3 @@ describe('mocha-each', () => {
     });
   });
 });
-


### PR DESCRIPTION
We have been using `mocha-each` and `chai-as-promised` and found a little issue. `chai-as-promised` allows you to return a promise from the function passed to `it`. Unfortunately `mocha-each` does not propagate this return value so tests unexpectedly pass. This PR adds propagating the return value.

Please let me know if there is any issue with this PR and I will fix it up.