### PR TITLE
add support for parameterization at `describe` level

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,36 @@ Result:
 
 ![Output](https://raw.githubusercontent.com/ryym/i/master/mocha-each/output.png)
 
+### At describe level
+
+Similarly, it works on describe level
+
+```javascript
+// test.js
+const assert = require('assert');
+const forEach = require('mocha-each');
+
+function subtract(a, b) {
+  return parseInt(a) - parseInt(b);
+}
+
+forEach([
+  [1, 1, 0],
+  [2, -2, 4],
+  [140, 48, 92]
+])
+.describe('subtract() with %d and %d', (left, right, expected) => {
+  let actual;
+  before(() => {
+    actual = subtract(left, right);
+  });
+
+  it('subtracts correctly and returns ' + expected, () => {
+    assert.equal(actual, expected);
+  });
+});
+```
+
 ### Asynchronous code
 
 When testing asynchronous code, you need to add a callback as a last argument of

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,15 +5,20 @@ module.exports = forEach;
 /**
  * Defines Mocha test cases for each given parameter.
  * @param {Array} parameters
- * @param {function} defaultIt - The 'it' function used in this function.
+ * @param {function} dIt - The 'it' function used in this function.
  *     If omitted, 'it' in global name space is used.
+ * @param {function} dDescribe - The 'describe' function used in this function.
+ *     If omitted, 'describe' in global name space is used.
  * @return {Object} The object which has a method to define test cases.
  */
-function forEach(parameters, defaultIt = global.it) {
-  const it = makeTestCaseDefiner(parameters, defaultIt);
-  it.skip = makeParameterizedSkip(parameters, defaultIt);
-  it.only = makeParameterizedOnly(parameters, defaultIt);
-  return { it };
+function forEach(parameters, dIt = global.it, dDescribe = global.describe) {
+  const it = makeTestCaseDefiner(parameters, dIt);
+  it.skip = makeParameterizedSkip(parameters, dIt);
+  it.only = makeParameterizedOnly(parameters, dIt);
+  const describe = makeTestCaseDefiner(parameters, dDescribe);
+  describe.skip = makeParameterizedSkip(parameters, dDescribe);
+  describe.only = makeParameterizedOnly(parameters, dDescribe);
+  return { it, describe };
 }
 
 /**

--- a/test/example.spec.js
+++ b/test/example.spec.js
@@ -31,6 +31,28 @@ describe('Example', () => {
     });
   });
 
+  function subtract(a, b) {
+    return parseInt(a) - parseInt(b);
+  }
+
+  /* Basic use at describe level */
+  forEach([
+    [1, 1, 0],
+    [2, -2, 4],
+    [140, 48, 92]
+  ])
+  .describe('subtract() with %d and %d', (left, right, expected) => {
+    let actual;
+
+    before(() => {
+      actual = subtract(left, right);
+    });
+
+    it('subtracts correctly and returns ' + expected, () => {
+      assert.equal(actual, expected);
+    });
+  });
+
   function letCry(animal) {
     switch(animal) {
     case 'dog': return 'bowow';


### PR DESCRIPTION
This addresses the suggestion: https://github.com/ryym/mocha-each/issues/2

Please let me know if there is any issue with this PR and I will fix it up.